### PR TITLE
Add Python_Min, Remove markupsafe & werkzeug

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,15 +16,13 @@ build:
 
 requirements:
   host:
-    - python >=3.8
+    - python {{ python_min }}
     - pip
     - setuptools
   run:
-    - python >=3.8
+    - python >={{ python_min }}
     - flask
-    - cachelib >=0.9.0, <0.10
-    - markupsafe
-    - werkzeug
+    - cachelib >=0.9.0,<0.10
 
 test:
   imports:
@@ -33,6 +31,7 @@ test:
   commands:
     - pip check
   requires:
+    - python {{ python_min }}
     - pip
 
 about:


### PR DESCRIPTION
https://github.com/pallets-eco/flask-caching/blob/v.2.3.0/setup.py

noarch: python recipes should usually follow the syntax in our documentation for specifying the Python version.

    For the host section of the recipe, you should usually use python {{ python_min }} for the python entry.
    For the run section of the recipe, you should usually use python >={{ python_min }} for the python entry.
    For the test.requires section of the recipe, you should usually use python {{ python_min }} for the python entry.
    If the package requires a newer Python version than the currently supported minimum version on conda-forge, you can override the python_min variable by adding a Jinja2 set statement at the top of your recipe (or using an equivalent context variable for v1 recipes).